### PR TITLE
Corrected issue-message.

### DIFF
--- a/src/main/java/com/example/google/lint/MainActivityDetector.java
+++ b/src/main/java/com/example/google/lint/MainActivityDetector.java
@@ -63,7 +63,7 @@ public class MainActivityDetector extends ResourceXmlDetector implements Detecto
             Severity.ERROR,
             new Implementation(
                     MainActivityDetector.class,
-                    EnumSet.of(Scope.MANIFEST)));
+                    Scope.MANIFEST_SCOPE));
 
     /**
      * This will be <code>true</code> if the current file we're checking has at least one activity.
@@ -104,7 +104,7 @@ public class MainActivityDetector extends ResourceXmlDetector implements Detecto
                 && mManifestLocation != null) {
             if (!mHasActivity) {
                 context.report(ISSUE, mManifestLocation,
-                        "Expecting " + ANDROID_MANIFEST_XML + " to have an <" + TAG_APPLICATION +
+                        "Expecting " + ANDROID_MANIFEST_XML + " to have an <" + TAG_ACTIVITY +
                                 "> tag.");
             } else if (!mHasLauncherActivity) {
                 // Report the issue if the manifest file has no activity with a launcher intent.

--- a/src/test/java/com/example/google/lint/MainActivityDetectorTest.java
+++ b/src/test/java/com/example/google/lint/MainActivityDetectorTest.java
@@ -140,7 +140,7 @@ public class MainActivityDetectorTest extends LintDetectorTest {
     public void testMissingApplication() throws Exception {
         mEnabled = Collections.singleton(MainActivityDetector.ISSUE);
         String expected = "AndroidManifest.xml: Error: Expecting AndroidManifest.xml to have an " +
-                "<application> tag. [MainActivityDetector]\n" +
+                "<activity> tag. [MainActivityDetector]\n" +
                 "1 errors, 0 warnings\n";
         String result = lintProject(xml(FN_ANDROID_MANIFEST_XML, "" +
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +


### PR DESCRIPTION
Hi,

first of all many thanks for publishing an official project for custom Lint rules. 👍🏻

I just noticed a minor issue. There was a misleading `issue message` if the manifest contains no `<activity>` tag. It states *"[...] AndroidManifest.xml to have an \<application\> tag [...]"*. But it's only looking for `<activity>`. Even if you add an `<application>` tag to the manifest in `testMissingApplication()` this `Issue` is still reported. So I assume it's an error. 

I fixed the message and the test case accordingly.

(I furthermore replaced `EnumSet.of(Scope.MANIFEST)` with the corresponding constant `Scope.MANIFEST_SCOPE` which is more readable IMHO).