### PR TITLE
Update gradle plugin version to 3.5.0

### DIFF
--- a/android-studio-3/build.gradle
+++ b/android-studio-3/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     ext {
-        gradlePluginVersion = '3.2.0-rc02'
-        lintVersion = '26.2.0-rc02'
+        gradlePluginVersion = '3.5.0'
+        lintVersion = '26.5.0'
     }
 
     repositories {

--- a/android-studio-3/checks/build.gradle
+++ b/android-studio-3/checks/build.gradle
@@ -4,10 +4,10 @@ dependencies {
     // For a description of the below dependencies, see the main project README
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
-    testCompile "junit:junit:4.12"
-    testCompile "com.android.tools.lint:lint:$lintVersion"
-    testCompile "com.android.tools.lint:lint-tests:$lintVersion"
-    testCompile "com.android.tools:testutils:$lintVersion"
+    testImplementation "junit:junit:4.12"
+    testImplementation "com.android.tools.lint:lint:$lintVersion"
+    testImplementation "com.android.tools.lint:lint-tests:$lintVersion"
+    testImplementation "com.android.tools:testutils:$lintVersion"
 }
 
 sourceCompatibility = "1.8"

--- a/android-studio-3/checks/src/main/java/com/example/lint/checks/SampleIssueRegistry.java
+++ b/android-studio-3/checks/src/main/java/com/example/lint/checks/SampleIssueRegistry.java
@@ -25,6 +25,7 @@ import java.util.List;
 /*
  * The list of issues that will be checked when running <code>lint</code>.
  */
+@SuppressWarnings("unused")
 public class SampleIssueRegistry extends IssueRegistry {
     @Override
     public List<Issue> getIssues() {

--- a/android-studio-3/gradle/wrapper/gradle-wrapper.properties
+++ b/android-studio-3/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 01 06:52:38 PDT 2017
+#Sat Sep 14 15:37:10 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android-studio-3/library/build.gradle
+++ b/android-studio-3/library/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 29
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
This ensures that the project works with the latest version of Android Studio.

Also updated a few minor cleanup things:

- Updated compile/target sdk version to 29
- Suppressed the unused warning for the lint registry class.
- Updated `testCompile` declarations to `testImplementation.