### PR TITLE
NF: correct markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ Please fill out either the individual or corporate Contributor License Agreement
 (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (https://developers.google.com/open-source/cla/individual).
+    own the intellectual property, then you'll need to sign an
+    [individual CLA](https://developers.google.com/open-source/cla/individual).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (https://developers.google.com/open-source/cla/corporate).
+    then you'll need to sign a
+    [corporate CLA](https://developers.google.com/open-source/cla/corporate).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to
@@ -28,9 +28,8 @@ accept your pull requests.
 1. Fork the desired repo, develop and test your code changes.
 1. Ensure that your code adheres to the existing style in the sample to which
    you are contributing. Refer to the
-   [Google Cloud Platform Samples Style Guide]
-   (https://github.com/GoogleCloudPlatform/Template/wiki/style.html) for the
-   recommended coding standards for this organization.
+   [Google Cloud Platform Samples Style Guide](https://github.com/GoogleCloudPlatform/Template/wiki/style.html)
+   for the recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request.
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ submitting a pull request through GitHub.
 
 License
 -------
-Licensed under the Apache 2.0 license. See the LICENSE file for details.
+Licensed under the Apache 2.0 license. See the [LICENSE](LICENSE) file for 
+details.
 
 How to make contributions?
 --------------------------
-Please read and follow the steps in the CONTRIBUTING.md
+Please read and follow the steps in the [CONTRIBUTING](CONTRIBUTING.md)


### PR DESCRIPTION
Github breaks link if [] and () are on distinct lines; in order for link to
works, your formatting was wrong.

Also, LICENCE and CONTRIBUTING.md should be link to the file

Compare https://github.com/Arthur-Milchior/android-custom-lint-rules/blob/main/CONTRIBUTING.md and https://github.com/googlesamples/android-custom-lint-rules/blob/main/CONTRIBUTING.md to see the difference