### PR TITLE
Update versions of AGP, Lint, and SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         lintVersion = '30.0.2'
 
         // Upcoming lint target: Bumble Bee / AGP 7.1
-        gradlePluginVersion = '7.1.0-alpha11'
-        lintVersion = '30.1.0-alpha11'
+        gradlePluginVersion = '7.1.0-alpha12'
+        lintVersion = '30.1.0-alpha12'
     }
 
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 31
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Target the latest versions of AGP (7.1.0-alpha12), Lint (30.1.0-alpha12), and compile/target SDK version (31).

Test: `./gradlew :app:lint` should only show one warning.  Prior to this change additional warnings appeared (such as not targeting the latest versions of Android)