### PR TITLE
fix: Correct typo in sample code

### DIFF
--- a/docs/api-guide.html
+++ b/docs/api-guide.html
@@ -1321,7 +1321,7 @@ be used instead:
 <span class="line"></span>        <span class="hljs-keyword">val</span> incident = Incident(context, ISSUE)
 <span class="line"></span>            .message( <span class="hljs-string">"Use `&lt;vector&gt;` instead of `&lt;bitmap&gt;`"</span>)
 <span class="line"></span>            .at(element)
-<span class="line"></span>        context.report(incident))
+<span class="line"></span>        context.report(incident)
 <span class="line"></span>    }
 <span class="line"></span>}</div></code></pre><p>
 

--- a/docs/api-guide/basics.md.html
+++ b/docs/api-guide/basics.md.html
@@ -787,7 +787,7 @@ class MyDetector : Detector(), XmlScanner {
         val incident = Incident(context, ISSUE)
             .message( "Use `<vector>` instead of `<bitmap>`")
             .at(element)
-        context.report(incident))
+        context.report(incident)
     }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Overview
The previous code had an unnecessary token in the sample code. This caused errors in the sample code. 

# Changes
- Removed unnecessary tokens `)`